### PR TITLE
Feat: add ch prefix to link cards automatically

### DIFF
--- a/src/commands/feat.ts
+++ b/src/commands/feat.ts
@@ -97,7 +97,7 @@ export default class Feat extends Command {
       validate: (name: string) => name.match(/^[0-9a-zA-Z-]+$/) ? true : false
     }])
 
-    const newBranchName = `${FEATURE_BRANCH_PREFIX}/${epicName}/${branchResponse.id}/${branchResponse.name}`
+    const newBranchName = `${FEATURE_BRANCH_PREFIX}/${epicName}/ch${branchResponse.id}/${branchResponse.name}`
 
     await git.checkoutBranch(newBranchName, genEpicBranchName(epicName))
     this.log(`Created branch ${newBranchName} from ${genEpicBranchName(epicName)}`)

--- a/src/commands/hotfix.ts
+++ b/src/commands/hotfix.ts
@@ -46,7 +46,7 @@ export default class Hotfix extends Command {
       validate: (name: string) => name.match(/^[0-9a-zA-Z]+$/) ? true : false
     }])
 
-    const newBranchName = `${HOTFIX_BRANCH_PREFIX}/${branchResponse.id}/${branchResponse.name}`
+    const newBranchName = `${HOTFIX_BRANCH_PREFIX}/ch${branchResponse.id}/${branchResponse.name}`
 
     await git.checkoutBranch(newBranchName, MASTER_BRANCH)
     this.log(`Created branch ${newBranchName} from ${MASTER_BRANCH}. Pulling from origin...`)


### PR DESCRIPTION
**CHANGELOG**

- Add `ch` prefix to tflow generated branches (feat and hotfix), that way they will link automatically with clubhouse tickets.